### PR TITLE
bug: Porudction deploy failing on release

### DIFF
--- a/.github/actions/deploy-app/action.yml
+++ b/.github/actions/deploy-app/action.yml
@@ -94,16 +94,7 @@ runs:
       if: steps.deploy.outputs.deployment-url == ''
       shell: sh
       run: |
-        echo "::warning::No deployment URL generated because preview URLs are disabled for this worker."
-        echo "::warning::Preview URLs need to be enabled manually in the Cloudflare dashboard."
-        echo "::notice::To enable preview URLs:"
-        echo "::notice::1. Go to Cloudflare Dashboard > Workers & Pages"
-        echo "::notice::2. Select your worker (invest-v3-${{ steps.wrangler-command.outputs.wrangler-env }})"
-        echo "::notice::3. Go to Settings > General"
-        echo "::notice::4. Enable 'Preview deployments'"
-        echo "::notice::5. Re-run this job or update the PR to get a deployment URL."
-        echo ""
-        echo "::notice::Note: This is a one-time setup. Once enabled, all future deployments will work automatically."
+        echo "::warning::Preview URLs disabled for ${{ steps.wrangler-command.outputs.wrangler-env }}. %0A Please enable from https://dash.cloudflare.com/${{ inputs.cloudflare-account-id }}/workers-and-pages"
 
 
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.action != 'prereleased'
+    if: github.event.action == 'prereleased'
     steps:
       - name: '📥 Checkout Code from Release Tag'
         uses: actions/checkout@v4
@@ -28,10 +28,12 @@ jobs:
           build-args: --mode mainnet
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  deploy:
+  deploy-staging:
     runs-on: ubuntu-latest
+    needs: build
+    if: github.event.action == 'prereleased'
     environment: 
-      name: ${{ github.event.action == 'prereleased' && 'staging' || 'production' }}
+      name: staging
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: '📥 Checkout Code'
@@ -39,11 +41,32 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: '🚀 Deploy App'
+      - name: '🚀 Deploy App to Staging'
         id: deploy
         uses: ./.github/actions/deploy-app
         with:
-          environment: ${{ github.event.action == 'prereleased' && 'staging' || 'prod' }}
+          environment: staging
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'released'
+    environment: 
+      name: production
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - name: '📥 Checkout Code'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: '🚀 Deploy App to Production'
+        id: deploy
+        uses: ./.github/actions/deploy-app
+        with:
+          environment: production
           cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,7 +16,7 @@ routes = [
 ]
 
 [env.prod]
-name   = "invest-v3-prod"        
+name   = "invest-v3"        
 routes = [
   { pattern = "app.centrifuge.io", custom_domain = true }
 ]


### PR DESCRIPTION

- Fix prerelease detection: Use github.event.action == 'prereleased' instead of github.event.release.prerelease
- Separate deploy jobs: Split into deploy-staging and deploy-production for cleaner separation
- Build once, deploy twice: Build only on prerelease, reuse artifacts for production deployment
- Cleaner error messages: Consolidate preview URL warnings into single, actionable messages