### PR TITLE
fix: formatting and schema balance value precision errors

### DIFF
--- a/src/cfg/utils/formatting.ts
+++ b/src/cfg/utils/formatting.ts
@@ -101,9 +101,24 @@ export function formatBigintToString(bigInt: bigint, bigintDecimals: number, for
   return Number(formatUnits(bigInt, bigintDecimals)).toFixed(decimals)
 }
 
-export function formatBalanceToString(amount: Balance, precision = 0) {
+export function formatBalanceToString(amount: Balance, precision?: number) {
   if (!(typeof amount === 'object' && 'decimals' in amount)) return ''
-  const decimalValue = new Decimal(amount.toFloat())
+
+  const bigIntValue = amount.toBigInt()
+  const decimals = amount.decimals
+  const valueStr = bigIntValue.toString().padStart(decimals + 1, '0')
+  const decimalIndex = valueStr.length - decimals
+  const integerPart = valueStr.slice(0, decimalIndex)
+  const fractionalPart = valueStr.slice(decimalIndex)
+  const fullDecimalString = `${integerPart}.${fractionalPart}`
+
+  // If no precision specified, return full precision string
+  // You'll need this for setting max values in createBalanceValidation schemas
+  if (precision === undefined) {
+    return fullDecimalString
+  }
+
+  const decimalValue = new Decimal(fullDecimalString)
   const truncatedValue = decimalValue.toDecimalPlaces(precision, Decimal.ROUND_DOWN)
 
   return truncatedValue.toString()

--- a/src/components/InvestRedeemSection/RedeemTab/RedeemTab.tsx
+++ b/src/components/InvestRedeemSection/RedeemTab/RedeemTab.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { z } from 'zod'
 import { Box, Spinner } from '@chakra-ui/react'
-import { createBalanceSchema, Form, safeParse, useForm } from '@forms'
+import { createBalanceSchema, createBalanceValidation, Form, safeParse, useForm } from '@forms'
 import { Balance } from '@centrifuge/sdk'
 import { formatBalanceToString, useCentrifugeTransaction } from '@cfg'
 import {
@@ -21,8 +21,8 @@ export function RedeemTab({ isLoading: isTabLoading, vault }: TabProps) {
 
   const maxRedeemAmount = useMemo(() => {
     if (maxRedeemBalance === 0) return ''
-
-    return formatBalanceToString(maxRedeemBalance, maxRedeemBalance.decimals) ?? ''
+    // Don't pass precision parameter to preserve full decimal precision for validation
+    return formatBalanceToString(maxRedeemBalance) ?? ''
   }, [maxRedeemBalance])
 
   function redeem(amount: Balance) {
@@ -32,7 +32,7 @@ export function RedeemTab({ isLoading: isTabLoading, vault }: TabProps) {
   const schema = z.object({
     redeemAmount: createBalanceSchema(
       investment?.shareBalance.decimals ?? 18,
-      z.number().min(1).max(Number(maxRedeemAmount))
+      createBalanceValidation({ min: 1, max: maxRedeemAmount }, investment?.shareBalance.decimals ?? 18)
     ),
     receiveAmount: createBalanceSchema(vaultDetails?.investmentCurrency.decimals ?? 6).optional(),
   })


### PR DESCRIPTION
The formatting and schema utility functions were using float values when handling Balance values, which are BigInts, causing precision errors. These were fixed to ensure no loss of precision during string formatting or schema parsing and validation.