### PR TITLE
fix: price chart values overflow

### DIFF
--- a/src/components/pools/poolDetails/PoolPerformanceChart.tsx
+++ b/src/components/pools/poolDetails/PoolPerformanceChart.tsx
@@ -89,8 +89,8 @@ export const PoolPerformanceChart = () => {
 
   const yDomain = useMemo(() => {
     if (!chartData || chartData.length === 0) return [0, 'dataMax']
-    const maxPrice = Number(Math.max(...chartData.map((d) => d.price)).toFixed(3))
-    const minPrice = Number(Math.min(...chartData.map((d) => d.price)).toFixed(3))
+    const maxPrice = Number(Math.max(...chartData.map((d) => d.price)).toFixed(2))
+    const minPrice = Number(Math.min(...chartData.map((d) => d.price)).toFixed(2))
     return [minPrice, maxPrice]
   }, [chartData])
 
@@ -130,9 +130,10 @@ export const PoolPerformanceChart = () => {
           height={260}
           data={chartData}
           yDomain={yDomain}
+          margin={{ top: 10, right: 10, bottom: 0, left: 0 }}
           xAccessor={(r) => r.timestamp}
           xTickFormatter={xTickFormatter}
-          yTickFormatter={(v) => String(v.toFixed(3))}
+          yTickFormatter={(v) => String(v.toFixed(2))}
           tooltipYTickFormatter={(v) => String(v.toFixed(6))}
           series={[
             {

--- a/src/hooks/useGetPoolsByIds.ts
+++ b/src/hooks/useGetPoolsByIds.ts
@@ -175,7 +175,7 @@ export function useGetPoolsByIds() {
   const getIsChroniclePool = (poolId?: string) => (poolId ? chroniclePoolIds.includes(poolId) : false)
   const getChroniclePoolIpfsUri = (poolId: string) => POOL_REGISTRY[poolId]?.chronicleIpfsUri
   const getIsTradingWidgetPool = (poolId?: string) =>
-    poolId ? (POOL_REGISTRY[poolId].hasTradingWidget ?? false) : false
+    poolId ? (POOL_REGISTRY[poolId]?.hasTradingWidget ?? false) : false
 
   return {
     chroniclePoolIds,


### PR DESCRIPTION
Fix for the Y values in the token price chart overflowing and being cut off if the numbers were too large.