### PR TITLE
feat: bump sdk version

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Audit dependencies with pnpm
         if: always()
         shell: sh
-        run: pnpm audit --audit-level moderate
+        # pnpm <11 hits HTTP 410 from the retired npm audit endpoint.
+        # Use pnpm v11 rc via dlx for the fixed bulk advisory API.
+        # Revert to plain `pnpm audit` once project upgrades to pnpm >=11.
+        # See: https://github.com/pnpm/pnpm/issues/11265
+        run: pnpm --config.minimumReleaseAge=0 dlx pnpm@11.0.0-rc.1 --config.manage-package-manager-versions=false audit --audit-level moderate
 
   osv-dependency-sec-check:
     permissions:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       "debug": "4.4.3",
       "defu": ">=6.1.5",
       "flatted": ">=3.4.2",
+      "follow-redirects@<=1.15.11": ">=1.16.0",
       "glob": ">=11.1.0",
       "h3": ">=1.15.9",
       "lodash": ">=4.18.0",
@@ -49,7 +50,7 @@
   },
   "dependencies": {
     "@ark-ui/react": "5.15.1",
-    "@centrifuge/sdk": "1.7.1",
+    "@centrifuge/sdk": "1.7.4",
     "@chakra-ui/react": "3.19.1",
     "@chakra-ui/system": "2.6.2",
     "@chakra-ui/theme": "3.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,14 @@ overrides:
   '@metamask/sdk': 0.33.1
   '@metamask/sdk-communication-layer': 0.33.1
   ajv@<7: 6.14.0
+  axios: '>=1.15.0'
   bn.js@<5: 4.12.3
   bn.js@>=5: 5.2.3
+  brace-expansion: '>=5.0.5'
   debug: 4.4.3
   defu: '>=6.1.5'
   flatted: '>=3.4.2'
+  follow-redirects@<=1.15.11: '>=1.16.0'
   glob: '>=11.1.0'
   h3: '>=1.15.9'
   lodash: '>=4.18.0'
@@ -30,9 +33,7 @@ overrides:
   rollup@>=4: 4.59.0
   undici: '>=7.24.0'
   viem: 2.40.2
-  brace-expansion: '>=5.0.5'
   yaml@<2: 1.10.3
-  axios: '>=1.15.0'
 
 importers:
 
@@ -42,8 +43,8 @@ importers:
         specifier: 5.15.1
         version: 5.15.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@centrifuge/sdk':
-        specifier: 1.7.1
-        version: 1.7.1(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+        specifier: 1.7.4
+        version: 1.7.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@chakra-ui/react':
         specifier: 3.19.1
         version: 3.19.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -347,8 +348,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@centrifuge/sdk@1.7.1':
-    resolution: {integrity: sha512-GGXbo3nTKZXXaI/8mcTt3ohVF+sCVQ8p1iOmTeyg4BoiYr+kwMiwaQ+JF8POAtlXW5vH2hhE8KdvIEHCTswP7g==}
+  '@centrifuge/sdk@1.7.4':
+    resolution: {integrity: sha512-u1LSE9p23cjzCxp3gf1fSN9DdWChU/wxhKoAMzE4A9a/tQA6nqf/Rd1QkAglxmnl40aj1GO5p1HTPS0/coeC0g==}
     engines: {node: '>=18.18'}
 
   '@chakra-ui/anatomy@2.2.2':
@@ -3689,8 +3690,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -5882,7 +5883,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@centrifuge/sdk@1.7.1(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@centrifuge/sdk@1.7.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@openzeppelin/merkle-tree': 1.0.8
       decimal.js-light: 2.5.1
@@ -9673,7 +9674,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -10528,7 +10529,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11:
+  follow-redirects@1.16.0:
     optional: true
 
   for-each@0.3.5:


### PR DESCRIPTION
The SDK update fixes the permit revert failure when investing USDC with Base and Avalanche.